### PR TITLE
fix(minio): correct architecture

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -f -SL https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.OFF
 	&& chmod 755 /usr/bin/mc \
 	&& mkdir /home/minio/.minio \
 	&& chown minio:minio /home/minio/.minio
-ADD https://dl.minio.io/server/minio/release/darwin-amd64/archive/minio.RELEASE.2016-06-03T19-32-05Z /bin/minio
+ADD https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2016-06-03T19-32-05Z /bin/minio
 RUN chmod 755 /bin/minio
 
 USER minio


### PR DESCRIPTION
Change the minio client binary back to the correct architecture.  Don't know exactly how I tested this change in teamhephy/minio#2 and thought it was good, but it wasn't.